### PR TITLE
[blocked on failing tests] Add Nix Flake and formatters

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+use flake

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,7 @@ repository.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [workspace]
-members = [
-    "crates/py2erg",
-]
+members = ["crates/py2erg"]
 
 [workspace.package]
 version = "0.0.27"
@@ -35,7 +33,11 @@ rustpython-parser = "0.1.2"
 
 [features]
 debug = ["erg_compiler/debug", "erg_common/debug", "py2erg/debug"]
-large_thread = ["erg_compiler/large_thread", "erg_common/large_thread", "els/large_thread"]
+large_thread = [
+  "erg_compiler/large_thread",
+  "erg_common/large_thread",
+  "els/large_thread",
+]
 pretty = ["erg_compiler/pretty", "erg_common/pretty"]
 backtrace = ["erg_common/backtrace"]
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,77 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1671636183,
+        "narHash": "sha256-dboEYqb7vnH9pVEwgaWz7dzVi7eh6N5tRuhJ/nluoCg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "60ff1ccd98a2f81347457a473c7a96b9b6166c88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1665296151,
+        "narHash": "sha256-uOB0oxqxN9K7XGF1hcnY+PQnlQJ+3bP2vCn/+Ru/bbc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "14ccaaedd95a488dd7ae142757884d8e125b3363",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1671589280,
+        "narHash": "sha256-FmJ4SC+Ewi1iMhdtRcrwirMfvW7h2jakT7ILLo9BVws=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "bfc54bcf98dacdc649c88a82bf14d00b399aa3bb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,6 +1,59 @@
 {
   "nodes": {
+    "devshell": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1683635384,
+        "narHash": "sha256-9goJTd05yOyD/McaMqZ4BUB8JW+mZMnZQJZ7VQ6C/Lw=",
+        "owner": "numtide",
+        "repo": "devshell",
+        "rev": "5143ea68647c4cf5227e4ad2100db6671fc4c369",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "devshell",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-utils": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
       "locked": {
         "lastModified": 1659877975,
         "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
@@ -17,20 +70,37 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1671636183,
-        "narHash": "sha256-dboEYqb7vnH9pVEwgaWz7dzVi7eh6N5tRuhJ/nluoCg=",
+        "lastModified": 1677383253,
+        "narHash": "sha256-UfpzWfSxkfXHnb4boXZNaKsAcUrZT9Hw+tao1oZxd08=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "60ff1ccd98a2f81347457a473c7a96b9b6166c88",
+        "rev": "9952d6bc395f5841262b006fbace8dd7e143b634",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1684120848,
+        "narHash": "sha256-gIwJ5ac1FwZEkCRwjY+gLwgD4G1Bw3Xtr2jr2XihMPo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0cb867999eec4085e1c9ca61c09b72261fa63bb4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
       "locked": {
         "lastModified": 1665296151,
         "narHash": "sha256-uOB0oxqxN9K7XGF1hcnY+PQnlQJ+3bP2vCn/+Ru/bbc=",
@@ -48,14 +118,17 @@
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs",
+        "devshell": "devshell",
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs_2",
         "rust-overlay": "rust-overlay"
       }
     },
     "rust-overlay": {
       "inputs": {
-        "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs_2"
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs_3"
       },
       "locked": {
         "lastModified": 1671589280,
@@ -68,6 +141,36 @@
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,47 @@
+{
+  description = "Example Rust development environment for Zero to Nix";
+
+  # Flake inputs
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs"; # also valid: "nixpkgs"
+    rust-overlay.url = "github:oxalica/rust-overlay"; # A helper for Rust + Nix
+  };
+
+  # Flake outputs
+  outputs = { self, nixpkgs, rust-overlay }:
+    let
+      # Overlays enable you to customize the Nixpkgs attribute set
+      overlays = [
+        # Makes a `rust-bin` attribute available in Nixpkgs
+        (import rust-overlay)
+      ];
+
+      # Systems supported
+      allSystems = [
+        "x86_64-linux" # 64-bit Intel/AMD Linux
+        "aarch64-linux" # 64-bit ARM Linux
+        "x86_64-darwin" # 64-bit Intel macOS
+        "aarch64-darwin" # 64-bit ARM macOS
+      ];
+
+      # Helper to provide system-specific attributes
+      forAllSystems = f: nixpkgs.lib.genAttrs allSystems (system: f {
+        pkgs = import nixpkgs { inherit overlays system; };
+      });
+    in
+    {
+      # Development environment output
+      devShells = forAllSystems ({ pkgs }: {
+        default = pkgs.mkShell {
+          # The Nix packages provided in the environment
+          packages = (with pkgs; [
+            darwin.apple_sdk.frameworks.Security
+            rust-bin.beta.latest.default
+            # # The package provided by our custom overlay. Includes cargo, Clippy, cargo-fmt,
+            # # rustdoc, rustfmt, and other tools.
+            # rustToolchain
+          ]) ++ pkgs.lib.optionals pkgs.stdenv.isDarwin (with pkgs; [ libiconv ]);
+        };
+      });
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -52,6 +52,7 @@
           cargo
           # Dev
           python3
+          treefmt # cli to run all formatters
           alejandra # Nix formatter
           rustfmt # Rust Formatter
           taplo-cli # TOML formatter

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,9 +7,9 @@ name = "pylyzer"
 description = "A fast static code analyzer & language server for Python"
 requires-python = ">=3.7"
 classifiers = [
-    "Development Status :: 2 - Pre-Alpha",
-    "Operating System :: OS Independent",
-    "Programming Language :: Python",
-    "Programming Language :: Rust",
-    "Topic :: Software Development :: Quality Assurance",
+  "Development Status :: 2 - Pre-Alpha",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python",
+  "Programming Language :: Rust",
+  "Topic :: Software Development :: Quality Assurance",
 ]

--- a/treefmt.toml
+++ b/treefmt.toml
@@ -1,0 +1,12 @@
+[formatter.alejandra]
+command = "alejandra"
+includes = ["*.nix"]
+
+[formatter.taplo]
+command = "taplo"
+options = ["format"]
+includes = ["*.toml"]
+
+[formatter.rustfmt]
+command = "rustfmt"
+includes = ["*.rs"]


### PR DESCRIPTION
Hello! 👋 

I wanted to build pylyzer on my local machine, so I copied the nix flake from the erg repo. Let me know if you prefer a solution where we re-use the flake from erg or something.

I've taken the liberty to format all the files using `treefmt` -- I noticed that some of the formatters are commented out on erg so please let me know if you want just the flake without taplo-cli, rustfmt, treefmt and the formatted files.

Build works:
```
❯ direnv allow .
direnv: loading ~/dev/pylyzer/.envrc
direnv: using flake
warning: Git tree '/Users/vshankar/dev/pylyzer' is dirty
[0/12 built, 3/61/69 copied (179.4/1228.0 MiB), 34.9/224.7 MiB DL] fetching stdenv-darwin from https://cache.nixos.orgdirenv: ([/nix/store/nv0l63gbpy84ih8wb94y4hn9pg8cigs8-direnv-2.32.1/bin/direnv export zsh]) is taking a while to execute. Use CTRL-C to give up.
warning: Git tree '/Users/vshankar/dev/pylyzer' is dirty
direnv: nix-direnv: renewed cache
🔨 Welcome to devshell

[general commands]

  menu - prints this menu

direnv: export +DEVSHELL_DIR +IN_NIX_SHELL +NIXPKGS_PATH +PRJ_DATA_DIR +PRJ_ROOT +name ~PATH ~XDG_DATA_DIRS

❯ rustc --version
rustc 1.69.0 (84c898d65 2023-04-16) (built from a source tarball)

❯ cargo --version
cargo 1.69.0

❯ cargo build
   Compiling autocfg v1.1.0
   Compiling libc v0.2.144
   Compiling proc-macro2 v1.0.56
   Compiling unicode-ident v1.0.8
   Compiling quote v1.0.27
   Compiling rand_core v0.4.2
   Compiling serde_derive v1.0.162
   Compiling serde v1.0.162
   Compiling siphasher v0.2.3
   Compiling typenum v1.16.0
   Compiling autocfg v0.1.8
   Compiling rand_core v0.3.1
   Compiling phf_shared v0.7.24
   Compiling memchr v2.5.0
   Compiling rand_hc v0.1.0
   Compiling rand_xorshift v0.1.1
   Compiling rand_pcg v0.1.2
   Compiling rand_chacha v0.1.1
   Compiling rand v0.6.5
   Compiling rand_isaac v0.1.1
   Compiling erg_common v0.6.13-nightly.4
   Compiling string_cache_shared v0.3.0
   Compiling rand_os v0.1.3
   Compiling rand_jitter v0.1.4
   Compiling syn v2.0.15
   Compiling byteorder v1.4.3
   Compiling byte-tools v0.3.1
   Compiling log v0.4.17
   Compiling block-padding v0.1.5
   Compiling dirs v1.0.5
   Compiling cfg-if v1.0.0
   Compiling regex-syntax v0.7.1
   Compiling lazy_static v1.4.0
   Compiling term v0.5.2
   Compiling num-traits v0.2.15
   Compiling generic-array v0.12.4
   Compiling aho-corasick v1.0.1
   Compiling fake-simd v0.1.2
   Compiling either v1.8.1
   Compiling digest v0.8.1
   Compiling block-buffer v0.7.3
   Compiling strsim v0.10.0
   Compiling phf_generator v0.7.24
   Compiling precomputed-hash v0.1.1
   Compiling fixedbitset v0.1.9
   Compiling string_cache_codegen v0.4.4
   Compiling opaque-debug v0.2.3
   Compiling new_debug_unreachable v1.0.4
   Compiling bit-vec v0.6.3
   Compiling ordermap v0.3.5
   Compiling tinyvec_macros v0.1.1
   Compiling sha2 v0.8.2
   Compiling tinyvec v1.6.0
   Compiling bit-set v0.5.3
   Compiling petgraph v0.4.13
   Compiling string_cache v0.7.5
   Compiling itertools v0.8.2
   Compiling regex v1.8.1
   Compiling ascii-canvas v2.0.0
   Compiling atty v0.2.14
   Compiling num-integer v0.1.45
   Compiling regex-syntax v0.6.29
   Compiling diff v0.1.13
   Compiling unicode-xid v0.1.0
   Compiling lalrpop-util v0.17.2
   Compiling ena v0.13.1
   Compiling unic-common v0.9.0
   Compiling unic-char-range v0.9.0
   Compiling unic-char-property v0.9.0
   Compiling unic-ucd-version v0.9.0
   Compiling unicode-normalization v0.1.22
   Compiling erg_compiler v0.6.13-nightly.4
   Compiling num-bigint v0.2.6
   Compiling percent-encoding v2.2.0
   Compiling unicode-xid v0.2.4
   Compiling serde_json v1.0.96
   Compiling unicode-bidi v0.3.13
   Compiling erg_parser v0.6.13-nightly.4
   Compiling idna v0.3.0
   Compiling form_urlencoded v1.1.0
   Compiling itoa v1.0.6
   Compiling ryu v1.0.13
   Compiling unic-emoji-char v0.9.0
   Compiling unic-ucd-ident v0.9.0
   Compiling serde_repr v0.1.12
   Compiling bitflags v1.3.2
   Compiling unicode_names2 v0.4.0
   Compiling docopt v1.1.1
   Compiling url v2.3.1
   Compiling lalrpop v0.17.2
   Compiling lsp-types v0.93.2
   Compiling rustpython-parser v0.1.2
   Compiling els v0.1.25-nightly.4
   Compiling py2erg v0.0.27 (/Users/vshankar/dev/pylyzer/crates/py2erg)
   Compiling pylyzer v0.0.27 (/Users/vshankar/dev/pylyzer)
    Finished dev [unoptimized + debuginfo] target(s) in 23.44s
warning: the following packages contain code that will be rejected by a future version of Rust: lalrpop v0.17.2
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 1`
```

Test fails, it seems to be related to how modules get imported. I printed out the errors for the import.py test, will look into fixing them
```
❯ cargo test
    Finished test [unoptimized + debuginfo] target(s) in 0.19s
warning: the following packages contain code that will be rejected by a future version of Rust: lalrpop v0.17.2
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 1`
     Running unittests src/lib.rs (target/debug/deps/pylyzer-a77f49866bfff0fc)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests src/main.rs (target/debug/deps/pylyzer-9981364b69006399)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/test.rs (target/debug/deps/test-b833d50a62a35663)

running 13 tests
test exec_narrowing ... ok
test exec_func ... ok
test exec_call ... ok
test exec_errors ... ok
test exec_export ... ok
test exec_warns ... ok
test exec_collections ... ok
test exec_casting ... ok
test exec_projection ... ok
test exec_test ... ok
test exec_class ... ok
test exec_typespec ... ok
test exec_import ... FAILED

failures:

---- exec_import stdout ----
Testing tests/import.py ...
errors: Error[#1889]: File tests/import.py, line 1, <module>

1 | import export
  : --------

module export not found

Error[#1889]: File tests/import.py, line 2, <module>

2 | import foo
  : -----

module foo not found

Error[#1565]: File tests/import.py, line 12, <module>

12 | rdi(0, 1, 2) # ERR
   : ---

too many arguments for .rdi(: (a: Int, b: Int) => Int)

total expected params:  2
passed positional args: 3
passed keyword args:    0

Error[#0633]: File tests/import.py, line 14, <module>

14 | print(export.test)
   :              ----

PyModule("export") object has no attribute test

Error[#0641]: File tests/import.py, line 15, <module>

15 | print(export.add(1, 2))
   :       ------
   :            |- expected: Set!(?T, ?N)
   :            `- but found: PyModule("export")

the type of _ is mismatched

Error[#0641]: File tests/import.py, line 16, <module>

16 | assert export.add("a", "b") == 1 # ERR
   :        ------
   :             |- expected: Set!(?T, ?N)
   :             `- but found: PyModule("export")

the type of _ is mismatched

Error[#1028]: File tests/import.py, line 18, <module>.c

18 | c = export.C(1)
   :            -

PyModule("export") object has no attribute C

Error[#0633]: File tests/import.py, line 19, <module>

19 | assert c.const == 1
   :          -----

Failure object has no attribute const

Error[#0633]: File tests/import.py, line 20, <module>

20 | assert c.x == 2
   :          -

Failure object has no attribute x

Error[#1028]: File tests/import.py, line 23, <module>.d

23 | d = export.D(1, 2)
   :            -

PyModule("export") object has no attribute D

Error[#0633]: File tests/import.py, line 24, <module>

24 | assert d.x == 1
   :          -

Failure object has no attribute x

Error[#0633]: File tests/import.py, line 25, <module>

25 | assert d.y == 2
   :          -

Failure object has no attribute y

Error[#0633]: File tests/import.py, line 27, <module>

27 | assert foo.i == 0
   :            -

PyModule("foo") object has no attribute i

Error[#0633]: File tests/import.py, line 39, <module>

39 | assert export.http.client.HTTPResponse == Resp
   :               ----

PyModule("export") object has no attribute http

Error[#0633]: File tests/import.py, line 39, <module>

39 | assert export.http.client.HTTPResponse == Resp
   :                    ------

Failure object has no attribute client

Error[#0633]: File tests/import.py, line 39, <module>

39 | assert export.http.client.HTTPResponse == Resp
   :                           ------------

Failure object has no attribute HTTPResponse


thread 'exec_import' panicked at 'assertion failed: `(left == right)`
  left: `16`,
 right: `2`', tests/test.rs:29:13
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    exec_import

test result: FAILED. 12 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.13s

```