### PR TITLE
Add --locked flag to cargo install

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ pip install pylyzer
 ### cargo (rust package manager)
 
 ```bash
-cargo install pylyzer
+cargo install pylyzer --locked
 ```
 
 ### build from source


### PR DESCRIPTION
Hi, in issue #65 some users reported compilation problems whilst attempting to install using `cargo install`. Adding the `--locked` flag ensures reproducible builds by utilising the exact set of dependencies that were available when the package was originally published. Incorporating this flag has resolved the installation issues, so it might be beneficial to include this information in the documentation.