### PR TITLE
feat: Version-independent wheel files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,11 +10,22 @@ from setuptools import setup, Command
 from setuptools_rust import RustBin
 import tomli
 
+try:
+    # setuptools >= 70.1.0
+    from setuptools.command.bdist_wheel import bdist_wheel
+except ImportError:
+    from wheel.bdist_wheel import bdist_wheel
+
 def removeprefix(string, prefix):
     if string.startswith(prefix):
         return string[len(prefix):]
     else:
         return string
+
+class BdistWheel(bdist_wheel):
+    def get_tag(self):
+        _, _, plat = super().get_tag()
+        return "py3", "none", plat
 
 class Clean(Command):
     user_options = []
@@ -68,6 +79,7 @@ setup(
     ],
     cmdclass={
         "clean": Clean,
+        "bdist_wheel": BdistWheel,
     },
     classifiers=[
         "Development Status :: 2 - Pre-Alpha",


### PR DESCRIPTION
Build python version-independent wheel files like [uv](https://pypi.org/project/uv/#files) or [ruff](https://pypi.org/project/ruff/#files).

First, thank you for making such a great package.

Currently, this project is currently uploading packages by Python version and implementation.
However, the project does not have Python source files, and the built binaries seem to have the same hash value on the same platform, so it should be fine to distribute the packages like [maturin's bin binding mode](https://www.maturin.rs/bindings#bin).

pypi has a size limit of 10GB for a single project. https://pypi.org/help/#project-size-limit
pylyzer's latest release is over 600MB for all wheel files together.
Hopefully this change will help.

