### PR TITLE
Fix: checking multiple files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,8 @@
     "[typescript]": {
         "editor.formatOnSave": true,
         "editor.defaultFormatter": "biomejs.biome"
-    }
+    },
+    "cSpell.words": [
+        "indexmap"
+    ]
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,6 +167,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "erg_common"
 version = "0.6.53-nightly.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -259,6 +265,12 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "heck"
@@ -406,6 +418,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.15.2",
+]
+
+[[package]]
 name = "is-macro"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -502,7 +524,7 @@ version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ea0ed76adf7defc1a92240b5c36d5368cfe9251640dcce5bd2d0b7c1fd87aeb"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.14.5",
  "itertools",
  "libm",
  "ryu",
@@ -733,6 +755,7 @@ dependencies = [
  "erg_common",
  "erg_compiler",
  "glob",
+ "indexmap",
  "pylyzer_core",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ pylyzer_core = { version = "0.0.81", path = "./crates/pylyzer_core" }
 erg_common = { workspace = true }
 els = { workspace = true }
 glob = "0.3.2"
+indexmap = "2.7.1"
 
 [dev-dependencies]
 erg_compiler = { workspace = true }

--- a/src/config.rs
+++ b/src/config.rs
@@ -214,7 +214,7 @@ For more information try `pylyzer --help`"
     cfg
 }
 
-pub(crate) fn files_to_be_checked() -> Vec<Result<PathBuf, String>> {
+pub(crate) fn files_to_be_checked() -> IndexSet<Result<PathBuf, String>> {
     let mut file_or_patterns = vec![];
     let mut args = env::args().skip(1);
     while let Some(arg) = &args.next() {
@@ -265,5 +265,5 @@ pub(crate) fn files_to_be_checked() -> Vec<Result<PathBuf, String>> {
             }
         }
     }
-    files.into_iter().collect()
+    files
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::env;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -218,19 +219,19 @@ pub(crate) fn files_to_be_checked() -> Vec<PathBuf> {
         .skip(1)
         .rev()
         .take_while(|arg| !arg.starts_with("-"));
-    let mut files = vec![];
+    let mut files = HashSet::new();
     for file_or_pattern in file_or_patterns {
         if PathBuf::from(&file_or_pattern).is_file() {
-            files.push(PathBuf::from(&file_or_pattern));
+            files.insert(PathBuf::from(&file_or_pattern));
         } else {
             for entry in glob::glob(&file_or_pattern).expect("Failed to read glob pattern") {
                 match entry {
                     Err(e) => eprintln!("err: {e}"),
-                    Ok(path) if path.is_file() => files.push(path),
+                    Ok(path) if path.is_file() => {files.insert(path);},
                     _ => {}
                 }
             }
         }
     }
-    files
+    files.into_iter().collect()
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -244,13 +244,13 @@ pub(crate) fn files_to_be_checked() -> IndexSet<Result<PathBuf, String>> {
             let entries = glob::glob(&file_or_pattern);
             match entries {
                 Err(_) => {
-                    files.insert(Err(file_or_pattern.clone()));
+                    files.insert(Err(file_or_pattern));
                     continue;
                 }
                 Ok(entries) => {
                     let mut entries = entries.into_iter().peekable();
                     if entries.peek().is_none() {
-                        files.insert(Err(file_or_pattern.clone()));
+                        files.insert(Err(file_or_pattern));
                     }
                     for entry in entries {
                         match entry {

--- a/src/config.rs
+++ b/src/config.rs
@@ -223,7 +223,7 @@ pub(crate) fn files_to_be_checked() -> Vec<Result<PathBuf, String>> {
                 // Discard runtime args
                 break;
             }
-            "--verbose" | "--code" | "-c" | "--disable" => {
+            "--code" | "-c" | "--disable" | "--verbose" => {
                 // Skip options
                 let _ = &args.next();
                 continue;

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,3 @@
-use std::collections::HashSet;
 use std::env;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -7,6 +6,7 @@ use erg_common::config::{ErgConfig, ErgMode};
 use erg_common::io::Input;
 use erg_common::pathutil::project_entry_file_of;
 use erg_common::switch_lang;
+use indexmap::IndexSet;
 
 use crate::copy::clear_cache;
 
@@ -50,7 +50,7 @@ OPTIONS
     --clear-cache                        キャッシュをクリア
     --code/-c cmd                        文字列をプログラムに渡す
     --dump-decl                          型宣言ファイルを出力
-    --disable                            指定した機能を無効化",
+    --disable feat                       指定した機能を無効化",
 
     "simplified_chinese" =>
     "\
@@ -68,7 +68,7 @@ OPTIONS
     --clear-cache                        清除缓存
     --code/-c cmd                        作为字符串传入程序
     --dump-decl                          输出类型声明文件
-    --disable                            禁用指定功能",
+    --disable feat                       禁用指定功能",
 
     "traditional_chinese" =>
         "\
@@ -86,7 +86,7 @@ OPTIONS
     --clear-cache                        清除快取
     --code/-c cmd                        作為字串傳入程式
     --dump-decl                          輸出類型宣告檔案
-    --disable                            禁用指定功能",
+    --disable feat                       禁用指定功能",
 
     "english" =>
         "\
@@ -104,7 +104,7 @@ OPTIONS
     --clear-cache                        clear cache
     --code/-c cmd                        program passed in as string
     --dump-decl                          output type declaration file
-    --disable                            disable specified features",
+    --disable feat                       disable specified features",
     )
 }
 
@@ -214,33 +214,49 @@ For more information try `pylyzer --help`"
     cfg
 }
 
-pub(crate) fn files_to_be_checked() -> (Vec<PathBuf>, Vec<String>) {
-    let file_or_patterns = env::args()
-        .skip(1)
-        .rev()
-        .take_while(|arg| !arg.starts_with("-"));
-    let mut files = HashSet::new();
-    let mut invalid_files = HashSet::new();
+pub(crate) fn files_to_be_checked() -> Vec<Result<PathBuf, String>> {
+    let mut file_or_patterns: Vec<String> = vec![];
+    let mut args = env::args().skip(1);
+    while let Some(arg) = &args.next() {
+        match arg.as_str() {
+            "--" => {
+                // Discard runtime args
+                break;
+            }
+            "--verbose" | "--code" | "-c" | "--disable" => {
+                // Skip options
+                let _ = &args.next();
+                continue;
+            }
+            file_or_pattern if file_or_pattern.starts_with("-") => {
+                // Skip flags
+                continue;
+            }
+
+            file_or_pattern => file_or_patterns.push(file_or_pattern.to_owned()),
+        }
+    }
+    let mut files = IndexSet::new();
     for file_or_pattern in file_or_patterns {
         if PathBuf::from(&file_or_pattern).is_file() {
-            files.insert(PathBuf::from(&file_or_pattern));
+            files.insert(Ok(PathBuf::from(&file_or_pattern)));
         } else {
             let entries = glob::glob(&file_or_pattern);
             match entries {
                 Err(_) => {
-                    invalid_files.insert(file_or_pattern.clone());
+                    files.insert(Err(file_or_pattern.clone()));
                     continue;
                 }
                 Ok(entries) => {
                     let mut entries = entries.into_iter().peekable();
                     if entries.peek().is_none() {
-                        invalid_files.insert(file_or_pattern.clone());
+                        files.insert(Err(file_or_pattern.clone()));
                     }
                     for entry in entries {
                         match entry {
                             Err(e) => eprintln!("err: {e}"),
                             Ok(path) if path.is_file() => {
-                                files.insert(path);
+                                files.insert(Ok(path));
                             }
                             _ => {}
                         }
@@ -249,8 +265,5 @@ pub(crate) fn files_to_be_checked() -> (Vec<PathBuf>, Vec<String>) {
             }
         }
     }
-    (
-        files.into_iter().collect(),
-        invalid_files.into_iter().collect(),
-    )
+    files.into_iter().collect()
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -215,7 +215,7 @@ For more information try `pylyzer --help`"
 }
 
 pub(crate) fn files_to_be_checked() -> Vec<Result<PathBuf, String>> {
-    let mut file_or_patterns: Vec<String> = vec![];
+    let mut file_or_patterns = vec![];
     let mut args = env::args().skip(1);
     while let Some(arg) = &args.next() {
         match arg.as_str() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,8 @@ mod copy;
 use els::Server;
 use erg_common::config::ErgMode;
 use erg_common::spawn::exec_new_thread;
+use erg_common::style::colors::RED;
+use erg_common::style::RESET;
 use pylyzer_core::{PythonAnalyzer, SimplePythonParser};
 
 use crate::config::files_to_be_checked;
@@ -17,7 +19,13 @@ fn run() {
         lang_server.run();
     } else {
         let mut code = 0;
-        let files = files_to_be_checked();
+        let (files, invalid_files) = files_to_be_checked();
+        for invalid_file in invalid_files {
+            if code == 0 {
+                code = 1;
+            }
+            println!("{RED}Invalid file or pattern{RESET}: {invalid_file}");
+        }
         if files.is_empty() {
             let mut analyzer = PythonAnalyzer::new(cfg);
             code = analyzer.run();

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,26 +19,27 @@ fn run() {
         lang_server.run();
     } else {
         let mut code = 0;
-        let (mut files, invalid_files) = files_to_be_checked();
-        for invalid_file in invalid_files {
-            if code == 0 {
-                code = 1;
-            }
-            println!("{RED}Invalid file or pattern{RESET}: {invalid_file}");
-        }
+        let files = files_to_be_checked();
         if files.is_empty() {
             let mut analyzer = PythonAnalyzer::new(cfg);
             code = analyzer.run();
         } else {
-            files.reverse();  // TODO: actually this only makes sense if not using a hashset
-            // TODO use a Vec<Result<PathBuf, String>> and keep the order?
-            //                                  ^- error msg
             for path in files {
-                let cfg = cfg.inherit(path);
-                let mut analyzer = PythonAnalyzer::new(cfg);
-                let c = analyzer.run();
-                if c != 0 {
-                    code = 1;
+                match path {
+                    Err(invalid_file_or_pattern) => {
+                        if code == 0 {
+                            code = 1;
+                        }
+                        println!("{RED}Invalid file or pattern{RESET}: {invalid_file_or_pattern}");
+                    }
+                    Ok(path) => {
+                        let cfg = cfg.inherit(path);
+                        let mut analyzer = PythonAnalyzer::new(cfg);
+                        let c = analyzer.run();
+                        if c != 0 {
+                            code = 1;
+                        }
+                    }
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ fn run() {
         lang_server.run();
     } else {
         let mut code = 0;
-        let (files, invalid_files) = files_to_be_checked();
+        let (mut files, invalid_files) = files_to_be_checked();
         for invalid_file in invalid_files {
             if code == 0 {
                 code = 1;
@@ -30,6 +30,9 @@ fn run() {
             let mut analyzer = PythonAnalyzer::new(cfg);
             code = analyzer.run();
         } else {
+            files.reverse();  // TODO: actually this only makes sense if not using a hashset
+            // TODO use a Vec<Result<PathBuf, String>> and keep the order?
+            //                                  ^- error msg
             for path in files {
                 let cfg = cfg.inherit(path);
                 let mut analyzer = PythonAnalyzer::new(cfg);


### PR DESCRIPTION
Discussion #125

## About the changes:

When users provide multiple files or patterns to check:
- duplicates are removed
- exit with status 1 if any pattern is an invalid pattern or does not match anything
- the files or patterns (valid or not) are returned **in order** (that's why I used ``IndexSet``, hope it's okay to add it as a dependancy)

## Results

You can test it yourself too, but here are a few screenshots:

User provides one valid file and a invalid glob pattern --> exit with 1

<img width="960" alt="image" src="https://github.com/user-attachments/assets/0d9a0dba-c93e-4663-afb0-bdf0661f0a74" />

Check that duplicates are removed, and ``good2.py´` is analyzed first

<img width="960" alt="image" src="https://github.com/user-attachments/assets/704bfeab-29bb-4190-8ae6-8be3ab9b5480" />

Check that options, flags and runtime args are skipped - full example

<img width="949" alt="image" src="https://github.com/user-attachments/assets/aa5b1d77-0edc-4859-9301-22fb42a50866" />

## Next steps

I'm waiting for your review, I'm new to Rust so feel free to tell me what could be improved / done in a more idiomatic way etc...

I ran cargo fmt and cargo clippy, but tell me if there are something else that I need to do.

And I will of course **squash** everything when we're good, and rebase if you want.
